### PR TITLE
Fix content when the tag changes

### DIFF
--- a/src/components/contenteditable.vue
+++ b/src/components/contenteditable.vue
@@ -102,5 +102,8 @@ watch( () => props.noHtml, (newval, oldval)  => {
   updateContent(props.modelValue ?? '')
 })
 
+watch( () => props.tag, (newval, oldval)  => {
+  updateContent(props.modelValue ?? "");
+}, { flush: 'post' });
 </script>
 


### PR DESCRIPTION
Hello,

When the `tag` property changes the content is lost because the element is created in the DOM but the content isn't injected.

This pull request calls `updateContent` when the property `tag` changes.

Greetings